### PR TITLE
from_handle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ impl Library {
         }
     }
 
+    pub fn from_handle(handle: *mut c_void) -> Result<Self> {
+        Ok(Self(handle))
+    }
+
     /// Load a symbol from the library.
     /// Note that the symbol name must end with '\0'.
     /// Limiting yourself to basic ASCII is also likely wise.


### PR DESCRIPTION
would we be willing to add something like this? i know it seems silly but i'm doing really weird low level "tricky" things on android where i'm trying to combat a blend of all sorts of things (JNI System.loadLibrary doesn't give you a handle you can use for dlsym but if you call minidl::Library::from it loads a 2nd instance of an already loaded library)

an alternative is to be able to supply flags to dlopen?